### PR TITLE
Spamassassin tuning, ignore big files and add feature to reject mails wi...

### DIFF
--- a/docs/vexim-acl-check-content.conf
+++ b/docs/vexim-acl-check-content.conf
@@ -25,7 +25,7 @@
   
   # Mails larger than 100 KB are accepted without spam-checking to save resources.
   # Typical Spam has only a few KB in size.
-  accept  condition = ${if >={$message_size}{100k}{yes}{no}}
+  #accept  condition = ${if >={$message_size}{100k}{yes}{no}}
 
   # Reject mails with more than 15 spam-points. This is a system-wide setting and does not respect
   # individual user settings!

--- a/docs/vexim-acl-check-content.conf
+++ b/docs/vexim-acl-check-content.conf
@@ -22,6 +22,16 @@
   # WARNING: this is an example !
   # deny  message = This message matches a blacklisted regular expression ($regex_match_string)
   #      regex = [Vv] *[Ii] *[Aa] *[Gg] *[Rr] *[Aa]
+  
+  # Mails larger than 100 KB are accepted without spam-checking to save resources.
+  # Typical Spam has only a few KB in size.
+  accept  condition = ${if >={$message_size}{100k}{yes}{no}}
+
+  # Reject mails with more than 15 spam-points. This is a system-wide setting and does not respect
+  # individual user settings!
+  #deny    message = This message has been rejected due to spam.
+  #        spam = maildeliver:true
+  #        condition = ${if >{$spam_score_int}{150}{true}{false}}
 
   # Always add X-Spam-Score and X-Spam-Report headers, using SA system-wide settings
   # (user "nobody"), no matter if over threshold or not.


### PR DESCRIPTION
...th high spam-score directly.

In some old configs, I found some improvements concerning the handling with spam mail:
- To save resources, only mails larger than 100 KB are scanned because typical spam is only about a few KB (per default on).
- The second option is to reject mails with spam scores higher than 15 directly. The interest is to avoid the handling of mails with a high spamassassin score. This concerns especially addresses which are forwarded to other  servers (e.g. googlemail). These forwarded messages are often rejected by the other server, then our server creates bounce-massages (backscatter) and can obtain a bad reputation. It is off by default. You have to verify first, that spamassassin is properly working, 15 is a more or less random value.