### PR TITLE
add spam_drop for alias-address

### DIFF
--- a/vexim/adminaliasadd.php
+++ b/vexim/adminaliasadd.php
@@ -3,7 +3,7 @@
   include_once dirname(__FILE__) . '/config/authpostmaster.php';
   include_once dirname(__FILE__) . '/config/functions.php';
   include_once dirname(__FILE__) . '/config/httpheaders.php';
-  $query = "SELECT avscan,spamassassin FROM domains
+  $query = "SELECT * FROM domains
     WHERE domain_id=:domain_id";
   $sth = $dbh->prepare($query);
   $sth->execute(array(':domain_id'=>$_SESSION['domain_id']));
@@ -69,18 +69,41 @@
           </tr>
           <?php
             if ($row['avscan'] == "1") {
-              print '<tr><td>' . _('Anti-Virus')
-                . ':</td><td>'
-                . '<input name="on_avscan" type="checkbox" class="textfield">'
-                . '</td></tr>';
-            }
-            if ($row['spamassassin'] == "1") {
-              print '<tr><td>' . _('Spamassassin')
-              . ':</td><td>'
-              . '<input name="on_spamassassin" type="checkbox" class="textfield">'
-              . '</td></tr>';
-            }
           ?>
+          <tr>
+            <td><?php echo _('Anti-Virus'); ?>:</td>
+            <td colspan="2"><input name="on_avscan" type="checkbox"></td>
+          </tr>
+          <?php } 
+            if ($row['spamassassin'] == "1") {
+          ?>
+          <tr>
+            <td><?php echo _('Spamassassin'); ?>:</td>
+            <td colspan="2"><input name="on_spamassassin" type="checkbox"></td>
+          </tr>
+          <tr>
+            <td><?php echo _('Spamassassin tag score'); ?>:</td>
+            <td colspan="2">
+              <input name="sa_tag" size="5" type="text" class="textfield"
+                value="<?php echo $row['sa_tag']; ?>"></td>
+          </tr>
+          <tr>
+            <td><?php echo _('Spamassassin refuse score'); ?>:</td>
+            <td colspan="2">
+              <input name="sa_refuse" size="5" type="text" class="textfield"
+                value="<?php echo $row['sa_refuse']; ?>">
+            </td>
+          </tr>
+          <tr>
+            <td><?php echo _('How to handle mail above the SA refuse score'); ?>:</td>
+            <td>
+             <input type="radio" id="off" name="spam_drop" value="0" checked>
+             <label for="off"> <?PHP echo _('forward Spam mails'); ?></label><br>
+             <input type="radio" id="on" name="spam_drop" value="1">
+             <label for="on"><?PHP echo _('delete Spam mails'); ?></label><br>
+            </td>
+          </tr>
+          <?php } ?>
           <tr>
             <td><?php echo _('Enabled'); ?>:</td>
             <td>

--- a/vexim/adminaliasaddsubmit.php
+++ b/vexim/adminaliasaddsubmit.php
@@ -57,9 +57,10 @@
   $aliasto = preg_replace("/[', ']+/", ",", $_POST['smtp']);
   if (alias_validate_password($_POST['clear'], $_POST['vclear'])) {
     $query = "INSERT INTO users
-      (localpart, username, domain_id, crypt, smtp, pop, uid, gid, realname, type, admin, on_avscan, on_spamassassin, enabled)
+      (localpart, username, domain_id, crypt, smtp, pop, uid, gid, realname, type, admin, on_avscan, 
+       on_spamassassin, sa_tag, sa_refuse, spam_drop, enabled)
       SELECT :localpart, :username, :domain_id, :crypt, :smtp, :pop, uid, gid, :realname, 'alias', :admin,
-      :on_avscan, :on_spamassassin, :enabled
+      :on_avscan, :on_spamassassin, :sa_tag, :sa_refuse, :spam_drop, :enabled
       FROM domains
       WHERE domains.domain_id=:domain_id";
     $sth = $dbh->prepare($query);
@@ -74,6 +75,9 @@
        ':admin' => $_POST['admin'],
        ':on_avscan' => $_POST['on_avscan'],
        ':on_spamassassin' => $_POST['on_spamassassin'],
+       ':sa_tag' => $_POST['sa_tag'],
+       ':sa_refuse' => $_POST['sa_refuse'],
+       ':spam_drop' => $_POST['spam_drop'],
        ':enabled' => $_POST['enabled']
        ));
        

--- a/vexim/adminaliaschange.php
+++ b/vexim/adminaliaschange.php
@@ -11,7 +11,16 @@
   if ($sth->rowCount()) {
     $row = $sth->fetch();
   }
+  $domquery = "SELECT avscan,spamassassin,quotas,pipe FROM domains
+    WHERE domain_id=:domain_id";
+  $domsth = $dbh->prepare($domquery);
+  $domsth->execute(array(':domain_id'=>$_SESSION['domain_id']));
+  if ($domsth->rowCount()) {
+    $domrow = $domsth->fetch();
+  }
 ?>
+
+
 <html>
   <head>
     <title><?php echo _('Virtual Exim') . ': ' . _('Manage Users'); ?></title>
@@ -99,6 +108,9 @@
               } ?> class="textfield">
             </td>
           </tr>
+          <?php
+           if ($domrow['avscan'] == "1") {
+        ?>
           <tr>
             <td><?php echo _('Anti-Virus'); ?>:</td>
             <td>
@@ -108,6 +120,10 @@
               } ?> class="textfield">
             </td>
           </tr>
+          <?php
+           }
+           if ($domrow['spamassassin'] == "1") {
+        ?>
           <tr>
             <td><?php echo _('Spamassassin'); ?>:</td>
             <td>
@@ -142,6 +158,9 @@
                <label for="on"><?PHP echo _('delete spam mails'); ?></label><br>
             </td>
           </tr>
+          <?php
+	   }
+          ?>
           <tr>
             <td><?php echo _('Enabled'); ?>:</td>
             <td>

--- a/vexim/adminaliaschange.php
+++ b/vexim/adminaliaschange.php
@@ -3,7 +3,7 @@
   include_once dirname(__FILE__) . '/config/authpostmaster.php';
   include_once dirname(__FILE__) . '/config/functions.php';
   include_once dirname(__FILE__) . '/config/httpheaders.php';
-  $query = "SELECT localpart,realname,smtp,on_avscan,on_spamassassin,
+  $query = "SELECT localpart,realname,smtp,on_avscan,on_spamassassin,sa_tag,sa_refuse,spam_drop,
     admin,enabled FROM users 	
 	WHERE user_id=:user_id AND domain_id=:domain_id AND type='alias'";
   $sth = $dbh->prepare($query);
@@ -115,6 +115,31 @@
               <?php if ($row['on_spamassassin'] == 1) {
                 print "checked";
               } ?> class="textfield">
+            </td>
+          </tr>
+          <tr>
+            <td><?php echo _('Spamassassin tag score'); ?>:</td>
+            <td>
+                <input type="text" size="5" name="sa_tag"
+                  value="<?php echo $row['sa_tag']; ?>" class="textfield">
+            </td>
+          </tr>
+          <tr>
+            <td><?php echo _('Spamassassin refuse score'); ?>:</td>
+            <td>
+                <input type="text" size="5" name="sa_refuse"
+                  value="<?php echo $row['sa_refuse']; ?>" class="textfield">
+            </td>
+          </tr>
+          <tr>
+            <td><?php echo _('How to handle mail above the SA refuse score'); ?>:</td>
+            <td>
+               <input type="radio" id="off" name="spam_drop" value="0"<?php if ($row['spam_drop'] == "0") {
+                  print " checked"; }?>>
+               <label for="off"> <?PHP echo _('forward spam mails'); ?></label><br>
+               <input type="radio" id="on" name="spam_drop" value="1"<?php if ($row['spam_drop'] == "1") {
+                  print " checked"; }?>>
+               <label for="on"><?PHP echo _('delete spam mails'); ?></label><br>
             </td>
           </tr>
           <tr>

--- a/vexim/adminaliaschangesubmit.php
+++ b/vexim/adminaliaschangesubmit.php
@@ -5,7 +5,7 @@
   include_once dirname(__FILE__) . '/config/httpheaders.php';
 
   # confirm that the postmaster is updating an alias they are permitted to change before going further  
-  $query = "SELECT localpart,realname,smtp,on_spamassassin,
+  $query = "SELECT localpart,realname,smtp,on_spamassassin,sa_tag,sa_refuse,spam_drop,
     admin,enabled FROM users 
 	WHERE user_id=:user_id AND domain_id=:domain_id AND type='alias'";
   $sth = $dbh->prepare($query);
@@ -69,7 +69,8 @@
   $query = "UPDATE users SET localpart=:localpart,
     username=:username, smtp=:smtp, pop=:pop,
     realname=:realname, admin=:admin, on_avscan=:on_avscan,
-    on_spamassassin=:on_spamassassin, enabled=:enabled
+    on_spamassassin=:on_spamassassin, sa_tag=:sa_tag, sa_refuse=:sa_refuse,
+    spam_drop=:spam_drop,enabled=:enabled
     WHERE user_id=:user_id
 	AND domain_id=:domain_id AND type='alias'";
   $sth = $dbh->prepare($query);
@@ -82,6 +83,9 @@
     ':admin'=>$_POST['admin'],
     ':on_avscan'=>$_POST['on_avscan'],
     ':on_spamassassin'=>$_POST['on_spamassassin'],
+    ':sa_tag'=>$_POST['sa_tag'],
+    ':sa_refuse'=>$_POST['sa_refuse'],
+    ':spam_drop'=>$_POST['spam_drop'],
     ':enabled'=>$_POST['enabled'],
     ':user_id'=>$_POST['user_id'],
     ':domain_id'=>$_SESSION['domain_id']

--- a/vexim/userchange.php
+++ b/vexim/userchange.php
@@ -41,6 +41,7 @@
       <form name="userchange" method="post" action="userchangesubmit.php">
 	</table>
 	<table align="center">
+         <?php if($row['type']!="alias") { ?>
 	  <tr><td colspan="2"><?php
 	    if ($row['quota'] != "0") {
 	      printf (_("Your mailbox quota is currently: %s Mb"), $row['quota']);
@@ -51,6 +52,7 @@
            </td>
 	  </tr>
         <?php
+          }
           if ($domrow['avscan'] == "1") {
         ?>
 	  <tr>
@@ -92,7 +94,7 @@
   	    <td>
                <input type="radio" id="off" name="spam_drop" value="0"<?php if ($row['spam_drop'] == "0") {
                   print " checked"; }?>>
-               <label for="off"> <?PHP echo _('move to Spam-folder'); ?></label><br>
+               <label for="off"> <?PHP if($row['type']=="alias") { echo _('forward spam mails'); } else { echo _('move to Spam-folder'); } ?></label><br>
                <input type="radio" id="on" name="spam_drop" value="1"<?php if ($row['spam_drop'] == "1") {
                   print " checked"; }?>>
                <label for="on"><?PHP echo _('delete - you cannot restore these mails'); ?></label><br>
@@ -100,6 +102,7 @@
   	  </tr>
           <?php
             }
+          if($row['type']!="alias") {
           ?>
   	  <tr>
   	    <td><?php echo _('Maximum message size'); ?>:</td>
@@ -139,11 +142,14 @@
         </td></tr>
   	  <tr><td><?php echo  _("Store Forwarded Mail Locally");?>:</td>
   	    <td><input name="unseen" type="checkbox"
-          <?php if($row['unseen'] == "1") { print " checked "; } ?>
+          <?php if($row['unseen'] == "1") { print " checked "; } ?>>
         </td></tr>
+      <?php }
+      ?>
   	  <tr><td></td><td class="button"><input name="submit" type="submit" value="<?php echo _("Submit Profile"); ?>"></td></tr>
   </table>
   </form>
+<?php if ($row['type']!="alias") { ?>
   <form name="blocklist" method="post" action="userblocksubmit.php">
     <table align="center">
   	  <tr><td><?php echo _("Add a new header blocking filter"); ?>:</td></tr>
@@ -168,6 +174,8 @@
       }
 	?>
       </table>
+<?php }
+?>
     </div>
   </body>
 </html>


### PR DESCRIPTION
We introduced the spam_drop-function that allowed the direct deletion of spam mails (instead of moving it to a special spam-directory. We didn't add this feature for alias-addresses (mail forwarding), all mails were forwarded. With this feature you can decide if a spam mail beyond the sa-refuse-tag is either deleted or forwarded.
Forwarded spam-mails can lead to a bad reputation of a mail server.