### PR TITLE
Fail if domain mail directory does not exist when creating a new domain. Fixes #71.

### DIFF
--- a/vexim/config/header.php
+++ b/vexim/config/header.php
@@ -84,6 +84,10 @@
     printf (_("-- Group %s could not be updated."), $_GET['group_failupdated']);
   } else if (isset($_GET['failuidguid'])) {
     printf (_("-- Error getting UID/GID for %s"), $_GET['failuidguid']);
+  } else if (isset($_GET['failmaildirnonabsolute'])) {
+    printf (_("-- Domain Mail directory must be an absolute path, but “%s” was provided"), $_GET['failmaildirnonabsolute']);
+  } else if (isset($_GET['failmaildirmissing'])) {
+    printf (_("-- Domain Mail directory “%s” does not exist, is not a directory or is not accessible."), $_GET['failmaildirmissing']);
   }
   if (isset($_GET['login']) && ($_GET['login'] == "failed")) { print _("Login failed"); }
 

--- a/vexim/config/variables.php.example
+++ b/vexim/config/variables.php.example
@@ -59,6 +59,12 @@
      Make sure the directory belongs to the configured $uid/$gid! */
   $mailroot = "/var/vmail/";
 
+  /* Check if mail store specified above exists when creating a new domain.
+     Generally, this shouldn't be disabled, but there may be special cases
+     when our check doesn't work and should be disabled (e.g. the parent
+     directory of mail store is inaccessible to your web server). */
+  $testmailroot = true;
+
   /* path to Mailman */
   $mailmanroot = "http://www.EXAMPLE.com/mailman";
 

--- a/vexim/siteaddsubmit.php
+++ b/vexim/siteaddsubmit.php
@@ -62,10 +62,21 @@
     die;
   }
   if(isset($_POST['maildir']) && isset($_POST['localpart'])) {
-    $smtphomepath = realpath($_POST['maildir'] . "/") .
-      "/" . $_POST['domain'] . "/" . $_POST['localpart'] . "/Maildir";
-    $pophomepath = realpath($_POST['maildir'] . "/") .
-      "/" . $_POST['domain'] . "/" . $_POST['localpart'];
+    if (substr($_POST['maildir'], 0, 1) !== '/') {
+      header ("Location: site.php?failmaildirnonabsolute={$_POST['maildir']}");
+	  die();
+    }
+    if ($testmailroot && is_dir(realpath($_POST['maildir'])) === false) {
+      header ("Location: site.php?failmaildirmissing={$_POST['maildir']}");
+      die();
+	}
+    $domainpath = $_POST['maildir'];
+    if (substr($domainpath, -1) !== '/') {
+      $domainpath .= '/';
+    }
+    $domainpath .= $_POST['domain'];
+    $smtphomepath = $domainpath . "/" . $_POST['localpart'] . "/Maildir";
+    $pophomepath = $domainpath . "/" . $_POST['localpart'];
   }
 //Gah. Transactions!! -- GCBirzan
   if ((validate_password($_POST['clear'], $_POST['vclear'])) &&
@@ -84,7 +95,7 @@
         ':sa_refuse'=>((isset($_POST['sa_refuse'])) ? $_POST['sa_refuse']  : 0),
         ':avscan'=>$_POST['avscan'], ':max_accounts'=>$_POST['max_accounts'],
         ':quotas'=>((isset($_POST['quotas'])) ? $_POST['quotas'] : 0),
-        ':maildir'=>realpath ($_POST['maildir'] . "/") . "/" . $_POST['domain'],
+        ':maildir'=>$domainpath,
         ':pipe'=>$_POST['pipe'], ':enabled'=>$_POST['enabled'],
         ':uid'=>$uid, ':gid'=>$gid, ':type'=>$_POST['type'],
         ':maxmsgsize'=>((isset($_POST['maxmsgsize'])) ? $_POST['maxmsgsize'] : 0)


### PR DESCRIPTION
We will also not substitute paths with the result of `realpath()` anymore, and will not accept paths not starting with a `/` character.
The check for actual existing of the directory may be disabled in settings, if that is necessary.